### PR TITLE
Fix code scanning alert no. 28: Regular expression injection

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -25,6 +25,7 @@ import type {
 
 const markdown = new MarkdownIt('zero');
 markdown.enable(['heading', 'lheading']);
+import _ from 'lodash';
 
 const repositoriesToSkipMdFetching = ['facebook/react-native'];
 
@@ -116,7 +117,8 @@ export function massageName(
   let name = input ?? '';
 
   if (version) {
-    name = name.replace(RegExp(`^(Release )?v?${version}`, 'i'), '').trim();
+    const safeVersion = _.escapeRegExp(version);
+    name = name.replace(RegExp(`^(Release )?v?${safeVersion}`, 'i'), '').trim();
   }
 
   name = name.trim();

--- a/package.json
+++ b/package.json
@@ -245,7 +245,8 @@
     "vuln-vects": "1.1.0",
     "xmldoc": "1.3.0",
     "yaml": "2.5.1",
-    "zod": "3.23.8"
+    "zod": "3.23.8",
+    "lodash": "^4.17.21"
   },
   "optionalDependencies": {
     "better-sqlite3": "11.3.0",


### PR DESCRIPTION
Fixes [https://github.com/automatik-engineering/renovate/security/code-scanning/28](https://github.com/automatik-engineering/renovate/security/code-scanning/28)

To fix the problem, we need to sanitize the `version` variable before embedding it into the regular expression. The best way to do this is by using a sanitization function such as `_.escapeRegExp` from the lodash library. This function escapes special characters in the input string, making it safe to use in a regular expression.

- **General fix:** Sanitize user input before embedding it into a regular expression.
- **Detailed fix:** Import the `_.escapeRegExp` function from lodash and use it to sanitize the `version` variable before constructing the regular expression.
- **Specific changes:** Modify the `massageName` function in `lib/workers/repository/update/pr/changelog/release-notes.ts` to sanitize the `version` variable.
- **Requirements:** Import the lodash library and use the `_.escapeRegExp` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
